### PR TITLE
Add ability to get the current verbosity level

### DIFF
--- a/stdlogr/logger.go
+++ b/stdlogr/logger.go
@@ -17,6 +17,10 @@ func SetVerbosity(v int) {
 	verbosity = v
 }
 
+func GetVerbosity() int {
+	return verbosity
+}
+
 func LimitToLoggers(names ...string) {
 	loggers = append(loggers, names...)
 }

--- a/stdlogr/logger.go
+++ b/stdlogr/logger.go
@@ -17,7 +17,7 @@ func SetVerbosity(v int) {
 	verbosity = v
 }
 
-func GetVerbosity() int {
+func Verbosity() int {
 	return verbosity
 }
 


### PR DESCRIPTION
This is useful when there is a lot of work to format the log message that we don't want to spend if the message won't actually be logged.